### PR TITLE
fix `toObjectAsync()` crash on empty object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Implement an object store keeping weak references to all objects returned to JavaScript and reusing them when possible
  - In TypeScript, return `JSON<any>` for `JSON.path()` when the string cannot be parsed by the type system instead of `never`
  - Allow the suppression of the exception in `.path()`
+ - Fix [#15](https://github.com/mmomtchev/everything-json/issues/15), `.toObjectAsync()` crash on empty objects
 
 ### [0.9.4] 2023-10-09
 

--- a/src/toObjectAsync.cc
+++ b/src/toObjectAsync.cc
@@ -171,8 +171,8 @@ void JSON::ToObjectAsync(shared_ptr<ToObjectAsync::Context> state, high_resoluti
       empty:
         // Primitive values -> increment the parent iterator
         // and recurse up as many levels as needed
-        bool backtracked;
-        do {
+        bool backtracked = true;
+        while (backtracked && previous) {
           backtracked = false;
           switch (previous->item.type()) {
           case element_type::ARRAY: {
@@ -203,7 +203,7 @@ void JSON::ToObjectAsync(shared_ptr<ToObjectAsync::Context> state, high_resoluti
           default:
             throw Error::New(env, "Internal error");
           }
-        } while (backtracked && previous);
+        }
       }
 
       // if previous == nullptr here, we have successfully

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -87,6 +87,18 @@ describe('from string', () => {
       .catch(done);
   });
 
+  it('toObjectAsync() w/ empty object', function (done) {
+    // https://github.com/mmomtchev/everything-json/issues/15
+    JSONAsync.parseAsync(JSON.stringify({}))
+      .then((document) => document.toObjectAsync())
+      .then((object) => {
+        assert.isObject(object);
+        assert.isEmpty(object);
+        done();
+      })
+      .catch(done);
+  });
+
   it('parse() throws on invalid JSON', () => {
     assert.throws(() => {
       JSONAsync.parse('invalid JSON');


### PR DESCRIPTION
Fixes #15 