### PR TITLE
Update package.json for compatibility with NodeNext resolution mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "homepage": "https://github.com/mmomtchev/everything-json#readme",
   "exports": {
+    "types": "./lib/index.d.ts",
     "import": "./lib/index.mjs",
-    "require": "./lib/index.cjs",
-    "types": "./lib/index.d.ts"
+    "require": "./lib/index.cjs"
   },
   "devDependencies": {
     "@octokit/core": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "homepage": "https://github.com/mmomtchev/everything-json#readme",
   "exports": {
     "import": "./lib/index.mjs",
-    "require": "./lib/index.cjs"
+    "require": "./lib/index.cjs",
+    "types": "./lib/index.d.ts"
   },
   "devDependencies": {
     "@octokit/core": "^6.0.1",


### PR DESCRIPTION
Starting from TypeScript 5.2, code written for Node must use `module: "NodeNext"`. However, it doesn't work for packages that include a single shared `index.d.ts` like this one because Node only looks for `index.d.cts` and `index.d.mts`. It's a common problem that's affects many packages: https://github.com/microsoft/TypeScript/issues/52363

Luckily, it's easy to fix.